### PR TITLE
:arrow_up: Ktor 3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
-    val kotlinVersion = "2.0.0"
+    val kotlinVersion = "2.1.0"
     val shadowVersion = "8.1.1"
     val versionsVersion = "0.51.0"
 
@@ -33,14 +33,14 @@ dependencies {
     val auth0JwtVersion = "4.4.0"
     val kotlinxCoroutinesVersion = "1.9.0"
     val kotlinxHtmlJvmVersion = "0.11.0"
-    val ktorVersion = "2.3.11"
+    val ktorVersion = "3.0.1"
     val micrometerVersion = "1.14.1"
     val logbackVersion = "1.5.12"
     val logstashVersion = "8.0"
     val mockkVersion = "1.13.13"
     val junitVersion = "5.11.3"
-    val navSecurityVersion = "5.0.5"
-    val tmsKtorTokenSupportVersion = "4.1.2"
+    val navSecurityVersion = "5.0.13"
+    val tmsKtorTokenSupportVersion = "5.0.0"
     val kotestVersion = "5.9.1"
 
     implementation("com.auth0:java-jwt:$auth0JwtVersion")
@@ -63,7 +63,7 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-    implementation("no.nav.security:token-validation-ktor-v2:$navSecurityVersion")
+    implementation("no.nav.security:token-validation-ktor-v3:$navSecurityVersion")
     implementation("no.nav.tms.token.support:tokendings-exchange:$tmsKtorTokenSupportVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")

--- a/src/main/kotlin/no/nav/navno/api/config/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/navno/api/config/Bootstrap.kt
@@ -9,7 +9,7 @@ import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
 import io.ktor.server.auth.authenticate
 import io.ktor.server.metrics.micrometer.MicrometerMetrics
-import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
@@ -18,7 +18,7 @@ import io.ktor.server.request.path
 import io.ktor.server.routing.routing
 import no.nav.navno.api.health.health
 import no.nav.navno.api.meldekort.meldekortApi
-import no.nav.security.token.support.v2.tokenValidationSupport
+import no.nav.security.token.support.v3.tokenValidationSupport
 
 fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()) {
     val environment = Environment()

--- a/src/test/kotlin/no/nav/navno/api/config/Bootstrap.kt
+++ b/src/test/kotlin/no/nav/navno/api/config/Bootstrap.kt
@@ -3,7 +3,7 @@ package no.nav.navno.api.config
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
-import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path


### PR DESCRIPTION
En frivillig sjel lagde enn PR i token-support-biblioteket for å støtte Ktor 3 :tada: 
Dette er det som skal til: https://github.com/navikt/personopplysninger-api/commit/92082c23728c04978e9143a0737553a88024baa8
- Bump ktor-versjon til 3.0.1 og fiks skrivefeil i import av CallLogging
- Bump nav-security-versjon til 5.0.13 og bruk token-validation-ktor-v3 i stedet for v2
- Bump tms-ktor-token-support til 5.0.0